### PR TITLE
Simplify examples

### DIFF
--- a/ocf-constructors/freezer.jif.json
+++ b/ocf-constructors/freezer.jif.json
@@ -10,11 +10,9 @@
   "defaultInterface": ["oic.if.b"],
   "properties": {
     "id": {
-      "interfaces": ["oic.if.baseline"],
       "value": "freezer"
     },
     "n": {
-      "interfaces": ["oic.if.baseline"],
       "value": "Freezer example"
     }
   },
@@ -24,7 +22,6 @@
     "oic.wk.col": {
       "properties": {
         "rts": {
-          "interfaces": ["oic.if.baseline"],
           "value": ["oic.r.temperature", "oic.r.conditionalnotification"]
         },
         "links": {

--- a/ocf-constructors/resource-internal.json
+++ b/ocf-constructors/resource-internal.json
@@ -63,7 +63,7 @@
         "value": 600
       },
       {
-        "name": "thresholdd",
+        "name": "threshold",
         "rt": ["oic.r.conditionalnotification"],
         "if": ["oic.if.r", "oic.if.rw"],
         "value": 1

--- a/ocf-constructors/temperature.batchcreate.json
+++ b/ocf-constructors/temperature.batchcreate.json
@@ -1,7 +1,7 @@
 
 [
   {
-    "href": "temperature",
+    "href": "/example/freezer/temperature",
     "rt": ["oic.r.temperature"],
     "if": ["oic.if.s"],
     "rep": {
@@ -11,21 +11,21 @@
     }
   },
   {
-    "href": "temperature",
-    "rt": ["oic.r.temperature", "oic.r.conditionalnotification"],
+    "href": "/example/freezer/temperature",
+    "rt": ["oic.r.temperature"],
     "if": ["oic.if.baseline"],
     "ins": "freezer.temperature",
     "title": "Freezer Temperature",
     "p": { "bm": 3 },
     "rep": {
-      "rt": ["oic.r.temperature", "oic.r.conditionalnotification"],
+      "rt": ["oic.r.temperature"],
       "if": ["oic.if.baseline"],
       "id": "freezer.temperature",
       "n": "Freezer Temperature"
     }
   },
   {
-    "href": "temperature",
+    "href": "/example/freezer/temperature",
     "rt": ["oic.r.temperature"],
     "if": ["oic.if.r"],
     "rep": {
@@ -36,7 +36,7 @@
     }
   },
   {
-    "href": "temperature",
+    "href": "/example/freezer/temperature",
     "rt": ["oic.r.conditionalnotification"],
     "if": ["oic.if.rw", "oic.if.r"],
     "rep": {

--- a/ocf-constructors/temperature.jif.json
+++ b/ocf-constructors/temperature.jif.json
@@ -10,11 +10,9 @@
   "defaultInterface": ["oic.if.s"],
   "properties": {
     "id": {
-      "interfaces": ["oic.if.baseline"],
       "value": "freezer.temperature"
     },
     "n": {
-      "interfaces": ["oic.if.baseline"],
       "value": "Freezer Temperature"
     }
   },
@@ -22,15 +20,13 @@
     "oic.r.temperature": {
       "properties": {
         "temperature": {
-          "interfaces": ["oic.if.s"],
+          "readOnly": true,
           "value": 0,
         },
         "units": {
-          "interfaces": ["oic.if.r"],
           "value": "C",
         },
         "range": {
-          "interfaces": ["oic.if.r"],
           "value": [0, 100],
         }
       }
@@ -38,15 +34,12 @@
     "oic.r.conditionalnotification": {
       "properties": {
         "minnotifyperiod": {
-          "interfaces": ["oic.if.r", "oic.if.rw"],
           "value": 10,
         },
         "maxnotifyperiod": {
-          "interfaces": ["oic.if.r", "oic.if.rw"],
           "value": 600,
         },
         "threshold": {
-          "interfaces": ["oic.if.r", "oic.if.rw"],
           "value": 1,
         }
       }

--- a/ocf-constructors/temperature.setpoint.jif.json
+++ b/ocf-constructors/temperature.setpoint.jif.json
@@ -10,11 +10,9 @@
   "defaultInterface": ["oic.if.a"],
   "properties": {
     "id": {
-      "interfaces": ["oic.if.baseline"],
       "value": "freezer.temperature.setpoint"
     },
     "n": {
-      "interfaces": ["oic.if.baseline"],
       "value": "Freezer Temperature Setpoint"
     }
   },
@@ -22,15 +20,12 @@
     "oic.r.temperature": {
       "properties": {
         "temperature": {
-          "interfaces": ["oic.if.s", "oic.if.a"],
           "value": 0,
         },
         "units": {
-          "interfaces": ["oic.if.r"],
           "value": "C",
         },
         "range": {
-          "interfaces": ["oic.if.r"],
           "value": [0, 100],
         }
       }
@@ -38,19 +33,15 @@
     "oic.r.action": {
       "properties": {
         "action.type": {
-          "interfaces": ["oic.if.r"],
           "value": "set-temperature",
         },
         "action.method": {
-          "interfaces": ["oic.if.r"],
           "value": "update",
         },
         "action.rt": {
-          "interfaces": ["oic.if.r"],
           "value": ["oic.r.temperature"],
         },
         "action.if": {
-          "interfaces": ["oic.if.r"],
           "value": ["oic.if.a"],
         }
       }


### PR DESCRIPTION
remove unnecessary interface definitions, use readONly override instead